### PR TITLE
Allow cancelling the call from the argument function

### DIFF
--- a/napi-thread-safe-callback.hpp
+++ b/napi-thread-safe-callback.hpp
@@ -5,6 +5,7 @@
 #include <future>
 #include <string>
 #include <vector>
+#include <exception>
 
 #ifndef NAPI_CPP_EXCEPTIONS
 #error ThreadSafeCallback needs napi exception support
@@ -28,6 +29,11 @@ class ThreadSafeCallback
         using completion_func_t = std::function<void(const Napi::Value&, const Napi::Error&)>;
 
         // Both functions will be called within the same HandleScope
+
+        // The argument function may throw CancelException to cancel the call
+        class CancelException : public std::exception {
+            const char* what() const throw();
+        };
 
         // Must be called from Node event loop because it calls napi_create_reference and uv_async_init
         ThreadSafeCallback(const Napi::Function& callback);
@@ -68,7 +74,7 @@ class ThreadSafeCallback
         void call();
         void call(arg_func_t arg_function);
         void callError(const std::string& message);
-        
+
     protected:
         // Cannot be copied or assigned
         ThreadSafeCallback(const ThreadSafeCallback&) = delete;

--- a/test/tests.js
+++ b/test/tests.js
@@ -213,7 +213,7 @@ describe('napi-thread-safe-callback.hpp', () => {
                 } catch (err) {
                     done(err);
                 }
-            })    
+            })
         });
     });
 
@@ -230,7 +230,7 @@ describe('napi-thread-safe-callback.hpp', () => {
                 }
             });
         });
-    
+
         it('should call callback with error', (done) => {
             tests.example_async_work((err, ...args) => {
                 try {
@@ -333,6 +333,13 @@ describe('napi-thread-safe-callback.hpp', () => {
                     done(err);
                 }
             });
+        });
+    });
+
+    describe('Throwing CancelError from argument callback', () => {
+        it('should not call callback', (done) => {
+            tests.call_cancel(() => done(new Error("called")))
+            setTimeout(done, 100);
         });
     });
 });


### PR DESCRIPTION
First, thank you for your work on this useful utility.

This PR suggests a mechanism to cancel the call from the argument function. This is necessary when the context changed between the scheduling of the call and the execution of the call (for instance, the user cancelled the operation or destroyed the corresponding object, and expects the callback not to be called anymore).

In order to be fully retro-compatible, it works with a dedicated `CancelException` exception which may be thrown by the argument function if the call can't be performed anymore.